### PR TITLE
player-data-struct: move 'game' variable to inside the PlayerData struct

### DIFF
--- a/game/packet/server.go
+++ b/game/packet/server.go
@@ -137,7 +137,6 @@ type ServerChannelList struct {
 type PlayerMainData struct {
 	ClientVersion common.PString
 	ServerVersion common.PString
-	Game          uint16
 	PlayerData    pangya.PlayerData
 	Unknown2      [321]byte
 }

--- a/game/server/auth.go
+++ b/game/server/auth.go
@@ -70,6 +70,7 @@ func (c *Conn) handleAuth(ctx context.Context) error {
 
 	// TODO: need data modelling
 	c.playerData = pangya.PlayerData{
+		Game: 0xFFFF,
 		UserInfo: pangya.PlayerInfo{
 			Username: c.player.Username,
 			Nickname: c.player.Nickname.String,
@@ -105,7 +106,6 @@ func (c *Conn) handleAuth(ctx context.Context) error {
 		MainData: &gamepacket.PlayerMainData{
 			ClientVersion: common.ToPString("824.00"),
 			ServerVersion: common.ToPString("Pangbox"),
-			Game:          0xFFFF,
 			PlayerData:    c.playerData,
 		},
 	})

--- a/pangya/player.go
+++ b/pangya/player.go
@@ -194,6 +194,7 @@ type PlayerMascotData struct {
 }
 
 type PlayerData struct {
+	Game              uint16
 	UserInfo          PlayerInfo
 	PlayerStats       PlayerStats
 	Trophy            [13][3]uint16


### PR DESCRIPTION
Move the `Game` variable from the `PlayerMainData` to the `PlayerData` struct. This is due that the `PlayerData` struct is also present when replying to the `User Info Request` packet in the following packet: https://packets.pangdox.com/packets/gameservice/server/0157.html

If we omit the `Game` from the struct and open the `My Info` tab we can observe alignment issues:
![image](https://github.com/pangbox/server/assets/4876366/612d3fba-0d6e-48bd-9c29-37d29d8c26d2)

By moving the variable we can see the correct alignment:
![image](https://github.com/pangbox/server/assets/4876366/7ef54bd6-489f-45fe-80f3-4e1dcb10ccc3)

**Note**: i did not test this with the pangbox server but with my own, though i do not expect any issues with the change 👀 