### PR TITLE
Partially Implement Papel Shop

### DIFF
--- a/game/packet/client.go
+++ b/game/packet/client.go
@@ -70,6 +70,7 @@ var ClientMessageTable = common.NewMessageTable(map[uint16]ClientMessage{
 	0x0082: &ClientMultiplayerLeave{},
 	0x0088: &Client0088{},
 	0x008B: &ClientRequestMessengerList{},
+	0x0098: &ClientRareShopOpen{},
 	0x009C: &ClientRequestPlayerHistory{},
 	0x00AE: &ClientTutorialClear{},
 	0x00B5: &ClientEnterMyRoom{},
@@ -81,10 +82,13 @@ var ClientMessageTable = common.NewMessageTable(map[uint16]ClientMessage{
 	0x0140: &ClientShopJoin{},
 	0x0143: &ClientRequestInboxList{},
 	0x0144: &ClientRequestInboxMessage{},
+	0x014B: &ClientBlackPapelPlay{},
+	0x0157: &ClientAchievementStatusRequest{},
 	0x016E: &ClientRequestDailyReward{},
 	0x0176: &ClientEventLobbyJoin{},
 	0x0177: &ClientEventLobbyLeave{},
 	0x0184: &ClientAssistModeToggle{},
+	0x0186: &ClientBigPapelPlay{},
 })
 
 // ClientAuth is a message sent to authenticate a session.
@@ -110,6 +114,11 @@ type ClientGetUserOnlineStatus struct {
 	ClientMessage_
 	Unknown  uint8
 	Username common.PString
+}
+
+// ClientRareShopOpen notifies the server if a user opens the rare shop menu.
+type ClientRareShopOpen struct {
+	ClientMessage_
 }
 
 // ClientRoomEdit is sent when the client changes room settings.
@@ -383,6 +392,12 @@ type ClientRequestMessengerList struct {
 	ClientMessage_
 }
 
+// ClientAchievementStatusRequest requests Achievement Status for a user.
+type ClientAchievementStatusRequest struct {
+	ClientMessage_
+	UserID uint32
+}
+
 // ClientGetUserData is a message sent by the client to request
 // the client state.
 type ClientGetUserData struct {
@@ -515,5 +530,13 @@ type ClientLockerInventoryRequest struct {
 }
 
 type Client00FE struct {
+	ClientMessage_
+}
+
+type ClientBlackPapelPlay struct {
+	ClientMessage_
+}
+
+type ClientBigPapelPlay struct {
 	ClientMessage_
 }

--- a/game/packet/server.go
+++ b/game/packet/server.go
@@ -73,6 +73,8 @@ var ServerMessageTable = common.NewMessageTable(map[uint16]ServerMessage{
 	0x00F1: &ServerMessageConnect{},
 	0x00F5: &ServerMultiplayerJoined{},
 	0x00F6: &ServerMultiplayerLeft{},
+	0x00FB: &ServerBlackPapelResponse{},
+	0x010B: &ServerRareShopOpen{},
 	0x010E: &ServerPlayerHistory{},
 	0x011F: &ServerTutorialStatus{},
 	0x012B: &ServerMyRoomEntered{},
@@ -89,13 +91,17 @@ var ServerMessageTable = common.NewMessageTable(map[uint16]ServerMessage{
 	0x0211: &ServerInboxList{},
 	0x0212: &ServerMailMessage{},
 	0x0216: &ServerUserStatusUpdate{},
+	0x021B: &ServerBlackPapelWinnings{},
 	0x021D: &ServerAchievementProgress{},
+	0x022C: &ServerAchievementUnknownResponse{},
+	0x022D: &ServerAchievementStatusResponse{},
 	0x0230: &Server0230{},
 	0x0231: &Server0231{},
 	0x0248: &ServerLoginBonusStatus{},
 	0x0250: &ServerEventLobbyJoined{},
 	0x0251: &ServerEventLobbyLeft{},
 	0x026A: &ServerAssistModeToggled{},
+	0x026C: &ServerBigPapelWinnings{},
 })
 
 // ConnectMessage is the message sent upon connecting.
@@ -250,6 +256,39 @@ type GamePlayer struct {
 	NumCards   uint8
 }
 
+type ServerRareShopOpen struct {
+	ServerMessage_
+	UnknownA int32
+	UnknownB int32
+	UnknownC uint32
+}
+
+type Achievement struct {
+	ID        uint32
+	Value     uint32
+	Timestamp uint32
+}
+
+type AchievementGroup struct {
+	GroupID      uint32
+	ID           uint32
+	Count        uint32 `struct:"sizeof=Achievements"`
+	Achievements []Achievement
+}
+
+type ServerAchievementStatusResponse struct {
+	ServerMessage_
+	Status    uint32
+	Remaining uint32
+	Count     uint32 `struct:"sizeof=Groups"`
+	Groups    []AchievementGroup
+}
+
+type ServerAchievementUnknownResponse struct {
+	ServerMessage_
+	UnknownA [4]byte
+}
+
 type GameInitFull struct {
 	NumPlayers byte `struct:"sizeof=Players"`
 	Players    []GamePlayer
@@ -299,7 +338,7 @@ type ServerRoomAction struct {
 	gamemodel.RoomAction
 }
 
-// ServerPangBalanceData is sent after a pang purchase succeeds.
+// ServerPangBalanceData is sent after a pang purchase succeeds.  Sometimes Pang Spent is not set like on Black Papel Transactions.
 type ServerPangBalanceData struct {
 	ServerMessage_
 	PangsRemaining uint64
@@ -877,4 +916,38 @@ type ServerEventLobbyLeft struct {
 type ServerAssistModeToggled struct {
 	ServerMessage_
 	Unknown uint32
+}
+
+type ServerBlackPapelWinnings struct {
+	ServerMessage_
+	Status                  uint32
+	BlackPapelInvTicketSlot uint32
+	UniqueItemsWon          uint32 `struct:"sizeof=Items"`
+	Items                   []ServerBlackPapelItems
+	PangsRemaining          uint64
+	CookiesRemaining        uint64 //not filled in but seems correct
+}
+
+type ServerBlackPapelResponse struct {
+	ServerMessage_
+	RemainingTurns int32
+	UnknownA       int32
+}
+
+type ServerBlackPapelItems struct {
+	DolfiniBallColor uint32
+	ItemTypeID       uint32
+	InventorySlot    uint32
+	Quantity         uint32
+	Rarity           uint32
+}
+
+type ServerBigPapelWinnings struct {
+	ServerMessage_
+	Status                  uint32
+	BlackPapelInvTicketSlot uint32
+	UniqueItemsWon          uint32 `struct:"sizeof=Items"`
+	Items                   []ServerBlackPapelItems
+	PangsRemaining          uint64
+	CookiesRemaining        uint64
 }

--- a/game/packet/server.go
+++ b/game/packet/server.go
@@ -925,7 +925,7 @@ type ServerBlackPapelWinnings struct {
 	UniqueItemsWon          uint32 `struct:"sizeof=Items"`
 	Items                   []ServerBlackPapelItems
 	PangsRemaining          uint64
-	CookiesRemaining        uint64 //not filled in but seems correct
+	CookiesRemaining        uint64 // not filled in but seems correct
 }
 
 type ServerBlackPapelResponse struct {

--- a/game/server/conn.go
+++ b/game/server/conn.go
@@ -471,10 +471,10 @@ func (c *Conn) Handle(ctx context.Context) error {
 				RemainingTurns: 50, // Displays as remaining turns in the box.
 				UnknownA:       -1,
 			})
-			// TODO make Pang interaction transactional
-			// TODO make items show up in inventory
-			// TODO make sure not to subtract pang if a ticket is used.
-			// TODO Fix pang able to go negative.
+			// TODO: make Pang interaction transactional
+			// TODO: make items show up in inventory
+			// TODO: make sure not to subtract pang if a ticket is used.
+			// TODO: Fix pang able to go negative.
 			c.player.Pang, err = c.s.accountsService.AddPang(ctx, c.player.PlayerID, -10000)
 			if err != nil {
 				return err
@@ -501,9 +501,9 @@ func (c *Conn) Handle(ctx context.Context) error {
 			packet.CookiesRemaining = uint64(c.player.Points) // Cookies remaining even if the action doesn't cost cookies
 			c.SendMessage(ctx, packet)
 		case *gamepacket.ClientBlackPapelPlay:
-			// TODO make Pang interaction transactional.
-			// TODO make items show up in inventory.
-			// TODO make sure not to subtract pang if a ticket is used.
+			// TODO: make Pang interaction transactional.
+			// TODO: make items show up in inventory.
+			// TODO: make sure not to subtract pang if a ticket is used.
 			c.player.Pang, err = c.s.accountsService.AddPang(ctx, c.player.PlayerID, -500)
 			if err != nil {
 				return err

--- a/game/server/server.go
+++ b/game/server/server.go
@@ -52,11 +52,19 @@ type Server struct {
 	configProvider  gameconfig.Provider
 	lobby           *room.Lobby
 	logger          *log.Entry
+	papelShop       *WeightedRand
+	papelRarity     map[uint32]uint32
 }
 
 // New creates a new instance of the game server.
 func New(opts Options) *Server {
 	logger := log.WithField("server", "GameServer")
+	papelShop := NewWeightedRand()
+	papelRarity := make(map[uint32]uint32)
+	for _, item := range opts.ConfigProvider.GetPapelShopOdds() {
+		papelShop.Add(item.TypeID, item.Weight)
+		papelRarity[item.TypeID] = uint32(item.Rarity)
+	}
 	return &Server{
 		baseServer:      &common.BaseServer{},
 		topologyClient:  opts.TopologyClient,
@@ -66,6 +74,8 @@ func New(opts Options) *Server {
 		channelName:     opts.ChannelName,
 		configProvider:  opts.ConfigProvider,
 		logger:          logger,
+		papelShop:       papelShop,
+		papelRarity:     papelRarity,
 	}
 }
 

--- a/game/server/weightedrandom.go
+++ b/game/server/weightedrandom.go
@@ -1,0 +1,69 @@
+// Copyright (C) 2023, John Chadwick <john@jchw.io>, JMC47
+//
+// Permission to use, copy, modify, and/or distribute this software for any purpose
+// with or without fee is hereby granted, provided that the above copyright notice
+// and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+// FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+// OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+// TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+// THIS SOFTWARE.
+//
+// SPDX-FileCopyrightText: Copyright (c) 2023 John Chadwick, JMC47
+// SPDX-License-Identifier: ISC
+
+package gameserver
+
+import (
+	"errors"
+	"math/rand"
+	"sort"
+)
+
+type WeightedRand struct {
+	cumulativeWeights []int64
+	values            []uint32
+	totalWeight       int64
+}
+
+func NewWeightedRand() *WeightedRand {
+	return &WeightedRand{}
+}
+
+func (w *WeightedRand) Add(value uint32, weight int64) error {
+	// Detect if the total weight is going to overflow
+	if w.totalWeight+weight < w.totalWeight {
+		return errors.New("total weight will overflow")
+	}
+
+	// Update total weight
+	w.totalWeight += weight
+
+	// Append the value
+	w.values = append(w.values, value)
+
+	// Compute cumulative weight
+	var cumulativeWeight int64
+	if len(w.cumulativeWeights) > 0 {
+		cumulativeWeight = w.cumulativeWeights[len(w.cumulativeWeights)-1] + weight
+	} else {
+		cumulativeWeight = weight
+	}
+	w.cumulativeWeights = append(w.cumulativeWeights, cumulativeWeight)
+
+	return nil
+}
+
+func (w *WeightedRand) Choose() uint32 {
+	// Generate a random number in the range [0, totalWeight)
+	r := rand.Int63n(w.totalWeight)
+
+	// Use binary search to find the index where our random number fits in
+	index := sort.Search(len(w.cumulativeWeights), func(i int) bool { return w.cumulativeWeights[i] > r })
+
+	// Return the corresponding value
+	return w.values[index]
+}

--- a/gameconfig/config.go
+++ b/gameconfig/config.go
@@ -1,3 +1,20 @@
+// Copyright (C) 2023, John Chadwick <john@jchw.io>, JMC47
+//
+// Permission to use, copy, modify, and/or distribute this software for any purpose
+// with or without fee is hereby granted, provided that the above copyright notice
+// and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+// FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+// OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+// TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+// THIS SOFTWARE.
+//
+// SPDX-FileCopyrightText: Copyright (c) 2023 John Chadwick, JMC47
+// SPDX-License-Identifier: ISC
+
 package gameconfig
 
 import (
@@ -27,6 +44,7 @@ type Provider interface {
 	GetDefaultClubSetTypeID() uint32
 	GetDefaultPang() uint64
 	GetCourseBonus(course uint8, numPlayers, numHoles int) uint64
+	GetPapelShopOdds() []ItemProbability
 }
 
 type CharacterDefaults struct {
@@ -45,6 +63,7 @@ type Manifest struct {
 	DefaultClubSetTypeID uint32              `json:"DefaultClubSetTypeID"`
 	DefaultPang          uint64              `json:"DefaultPang"`
 	CourseBonusRate      []CourseBonusRate   `json:"CourseBonusRate"`
+	PapelShopOdds        []ItemProbability   `json:"PapelShopOdds"`
 }
 
 type configFileProvider struct {
@@ -52,6 +71,13 @@ type configFileProvider struct {
 	defaultClubSetTypeID uint32
 	defaultPang          uint64
 	courseBonusRate      map[uint8]int
+	papelShopOdds        []ItemProbability
+}
+
+type ItemProbability struct {
+	TypeID uint32
+	Weight int64
+	Rarity uint32
 }
 
 func Default() Provider {
@@ -88,6 +114,7 @@ func FromManifest(manifest Manifest) Provider {
 		defaultClubSetTypeID: manifest.DefaultClubSetTypeID,
 		defaultPang:          manifest.DefaultPang,
 		courseBonusRate:      make(map[uint8]int),
+		papelShopOdds:        manifest.PapelShopOdds,
 	}
 	for _, defaults := range manifest.CharacterDefaults {
 		provider.characterDefaults[defaults.CharacterID] = defaults
@@ -119,4 +146,8 @@ func (c *configFileProvider) GetCourseBonus(course uint8, numPlayers, numHoles i
 
 	// TODO: this is probably only true for versus
 	return uint64(bonusRate * numHoles * (numPlayers - 1))
+}
+
+func (c *configFileProvider) GetPapelShopOdds() []ItemProbability {
+	return c.papelShopOdds
 }

--- a/gameconfig/default.json
+++ b/gameconfig/default.json
@@ -24,5 +24,24 @@
         {"CourseID": 19, "CourseName": "Wiz City", "BonusRate": 40},
         {"CourseID": 20, "CourseName": "Abbot Mine", "BonusRate": 40},
         {"CourseID": 64, "CourseName": "Grand Zodiac", "BonusRate": 20}
+    ],
+    "PapelShopOdds": [
+        {"TypeID":402653184,"Weight":100, "Rarity":0},
+        {"TypeID":402653185,"Weight":100, "Rarity":0},
+        {"TypeID":402653188,"Weight":90, "Rarity":0},
+        {"TypeID":402653188,"Weight":90, "Rarity":0},
+        {"TypeID":402653192,"Weight":150, "Rarity":0},
+        {"TypeID":402653191,"Weight":150, "Rarity":0},
+        {"TypeID":436207657,"Weight":20, "Rarity":0},
+        {"TypeID":402653190,"Weight":20, "Rarity":1},
+        {"TypeID":335544321,"Weight":20, "Rarity":1},
+        {"TypeID":402653193,"Weight":20, "Rarity":1},
+        {"TypeID":335544322,"Weight":20, "Rarity":1},
+        {"TypeID":335544323,"Weight":20, "Rarity":1},
+        {"TypeID":335544325,"Weight":20, "Rarity":1},
+        {"TypeID":436207616,"Weight":35, "Rarity":1},
+        {"TypeID":402653194,"Weight":20, "Rarity":1},
+        {"TypeID":402653195,"Weight":20, "Rarity":1},
+        {"TypeID":135544902,"Weight":2, "Rarity":2}
     ]
 }


### PR DESCRIPTION
Partial implementation of the Papel Shop.

Also implements bare necessities to open the rare shop page at all, which means faking achievement data (for memorial shop.)  Also adds a WeightedRandom generation.

The Papel Shop itself does visually function, though there are some packet differences between US852 and the reference packet that causes some functionality to be odd.  Note that both shops will subtract pang, but you don't actually get the items.  I put a random rare item in just for fun, but otherwise tried to match known Papel Shop items from dumped packets.

Big Papel wasn't something I used as much, so I'm not nearly as sure on the implementation.  It matches what data I have, but there is a bug saying it has no more rolls.  This server ignores that bug and lets you roll anyway, so it can be tested and waste your pang.  Big Papel shop is weird and will let your pang go negative, which the game seems totally fine with doing, surprisingly enough.  Black Papel shop has a client side check and does not allow you to go negative.