### PR TITLE
bug: fix player character data struct stats alignment

### DIFF
--- a/pangya/player.go
+++ b/pangya/player.go
@@ -150,8 +150,9 @@ type PlayerCharacterData struct {
 	Unknown3    [216]byte
 	AuxParts    [5]uint32
 	CutInID     uint32
-	Unknown4    [16]byte
+	Unknown4    [12]byte
 	Stats       [5]byte
+	Mastery     uint32
 	CardChar    [4]uint32
 	CardCaddie  [4]uint32
 	CardNPC     [4]uint32


### PR DESCRIPTION
If we try to give the player N power slots with the current struct layout we'll observe that they do not work but instead are allocated to the curve stat.

Base stats:
![image](https://github.com/pangbox/server/assets/4876366/a24ac93e-dbbb-4178-9512-995df16ca556)

Equipping a power item with power slot = 1, here we'd expect our power to be 28:
![image](https://github.com/pangbox/server/assets/4876366/113e613d-1a40-48d1-8eee-9e79322b227e)

Yet if we equip a curve item, we can see it is raised to 14 instead of the expected 13:
![image](https://github.com/pangbox/server/assets/4876366/ea35317a-aee7-48c9-98ee-30cdd788798e)

The offsetted 4 bytes after the stats array is actually the character mastery level (0-10), if we set to 10 we can see the extra bonuses on the Character Mastery screen:
![image](https://github.com/pangbox/server/assets/4876366/6ccb92a5-e943-4458-99ae-237508bbd486)

